### PR TITLE
Manually implement `Clone` for `MPMCFut*` types

### DIFF
--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -85,14 +85,12 @@ pub struct MPMCUniReceiver<T> {
 
 /// This is the futures-compatible version of ```MPMCSender```
 /// It implements Sink
-#[derive(Clone)]
 pub struct MPMCFutSender<T> {
     sender: FutInnerSend<MPMC<T>, T>,
 }
 
 /// This is the futures-compatible version of ```MPMCReceiver```
 /// It implements Stream
-#[derive(Clone)]
 pub struct MPMCFutReceiver<T> {
     receiver: FutInnerRecv<MPMC<T>, T>,
 }
@@ -512,6 +510,14 @@ impl<R, F: FnMut(&T) -> R, T> MPMCFutUniReceiver<R, F, T> {
     }
 }
 
+impl<T> Clone for MPMCFutSender<T> {
+    fn clone(&self) -> Self {
+        MPMCFutSender {
+            sender: self.sender.clone(),
+        }
+    }
+}
+
 impl<T> Sink for MPMCFutSender<T> {
     type SinkItem = T;
     type SinkError = SendError<T>;
@@ -524,6 +530,14 @@ impl<T> Sink for MPMCFutSender<T> {
     #[inline(always)]
     fn poll_complete(&mut self) -> Poll<(), SendError<T>> {
         Ok(Async::Ready(()))
+    }
+}
+
+impl<T> Clone for MPMCFutReceiver<T> {
+    fn clone(&self) -> Self {
+        MPMCFutReceiver {
+            receiver: self.receiver.clone(),
+        }
     }
 }
 

--- a/src/multiqueue.rs
+++ b/src/multiqueue.rs
@@ -180,7 +180,6 @@ pub struct InnerRecv<RW: QueueRW<T>, T> {
 }
 
 /// This is a sender that can transparently act as a futures stream
-#[derive(Clone)]
 pub struct FutInnerSend<RW: QueueRW<T>, T> {
     writer: InnerSend<RW, T>,
     wait: Arc<FutWait>,
@@ -188,7 +187,6 @@ pub struct FutInnerSend<RW: QueueRW<T>, T> {
 }
 
 /// This is a receiver that can transparently act as a futures stream
-#[derive(Clone)]
 pub struct FutInnerRecv<RW: QueueRW<T>, T> {
     reader: InnerRecv<RW, T>,
     wait: Arc<FutWait>,
@@ -969,6 +967,26 @@ impl<RW: QueueRW<T>, T> Clone for InnerRecv<RW, T> {
             reader: self.reader.clone(),
             token: self.queue.manager.get_token(),
             alive: true,
+        }
+    }
+}
+
+impl<RW: QueueRW<T>, T> Clone for FutInnerSend<RW, T> {
+    fn clone(&self) -> FutInnerSend<RW, T> {
+        FutInnerSend {
+            writer: self.writer.clone(),
+            wait: self.wait.clone(),
+            prod_wait: self.prod_wait.clone(),
+        }
+    }
+}
+
+impl<RW: QueueRW<T>, T> Clone for FutInnerRecv<RW, T> {
+    fn clone(&self) -> FutInnerRecv<RW, T> {
+        FutInnerRecv {
+            reader: self.reader.clone(),
+            wait: self.wait.clone(),
+            prod_wait: self.prod_wait.clone(),
         }
     }
 }


### PR DESCRIPTION
`#[derive(Clone)]` infers a `_: Clone` bound for all parameters on the type, which (generally) is a safe default but is too restrictive for cases like this. That restriction might be lifted at some point (rust-lang/rust#40754) but for now, a manual `Clone` impl works better.