### PR TITLE
Documentation Fixes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -79,9 +79,9 @@ The lines are meant to show the data flow through the queue.
     /      \
 -> #        @-3
 ```
-This is a pretty standard broadcast queue setup - 
+This is a pretty standard broadcast queue setup -
 for each element sent in, it is seen on each stream by that's streams consumer.
- 
+
 
 However, in MultiQueue, each logical consumer might actually be demultiplexed across many actual consumers, like below.
 ```
@@ -96,7 +96,7 @@ If this diagram is redrawn with each of the producers sending in a sequenced ele
 
 
 ```
-t=1|t=2|    t=3    | t=4| 
+t=1|t=2|    t=3    | t=4|
 1 -> #              @-1 (1, 2)
       \            /
        -> 2 -> 1 -> -> @-2' (really @ (1) + @ (2) + @ (nothing yet))
@@ -338,7 +338,7 @@ Single Producer Single Consumer, broadcasted to two different streams: 28 millio
 ```
          @
         /
-# -> ->   
+# -> ->
         \
          @
 ```
@@ -365,7 +365,7 @@ Multi Producer Single Consumer, broadcast to two different streams: 8 million op
 ```
 #        @
  \      /
-  -> -> 
+  -> ->
  /      \
 #        @
 ```
@@ -419,7 +419,7 @@ up to date with the individual feeds and markets fall into disarray.
 but then gotten stuck will block readers from progressing. There is a lockless MPMC bounded queue,
 but it requires a statically known max senders and I don't think can be extended to broadcast.
 In practice, it will rarely ever matter.
- 
+
 <a name = "ft2">2</a> These benchmarks had extremely varying benchmarks so I took the upper bound. On some other machines
 they showed only minor performance differences compared to the spsc case so
 I think in practice the effective throughput will be much higher

--- a/Readme.md
+++ b/Readme.md
@@ -153,7 +153,7 @@ extern crate multiqueue;
 
 use std::thread;
 
-let (send, recv) = multiqueue::multicast_queue(4);
+let (send, recv) = multiqueue::broadcast_queue(4);
 
 for i in 0..2 { // or n
     let cur_recv = recv.add_stream();
@@ -199,7 +199,7 @@ extern crate multiqueue;
 
 use std::thread;
 
-let (send, recv) = multiqueue::multicast_queue(4);
+let (send, recv) = multiqueue::broadcast_queue(4);
 
 for i in 0..2 { // or n
     let cur_recv = recv.add_stream();
@@ -249,7 +249,7 @@ extern crate multiqueue;
 
 use std::thread;
 
-let (send, recv) = multiqueue::multicast_queue(4);
+let (send, recv) = multiqueue::broadcast_queue(4);
 
 // start like before
 for i in 0..2 { // or n

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! In many cases, ```MultiQueue``` will be a good replacement for channels and it's broadcast
 //! capabilities can replace more complex concurrency systems with a single queue.
 //!
-//! #Queue Model:
+//! # Queue Model:
 //! ```MultiQueue``` functions similarly to the LMAX Disruptor from a high level view.
 //! There's an incoming FIFO data stream that is broadcast to a set of subscribers
 //! as if there were multiple streams being written to.
@@ -77,20 +77,20 @@
 //! the workload completely on one core, @-2 is doing expensive work handling requests
 //! and is split into multiple workers dealing with the data stream.
 //!
-//! #MPMC Mode:
+//! # MPMC Mode:
 //! One might notice that the broadcast queue modes requires that a type be Clone,
 //! and the single-reader inplace variants require that a type be Sync as well.
 //! This is only required for broadcast queues and not normal mpmc queues,
 //! so there's an mpmc api as well. It doesn't require that a type be Clone or Sync
 //! for any api, and also moves items directly out of the queue instead of cloning them.
 //!
-//! #Futures Mode:
+//! # Futures Mode:
 //! For both mpmc and broadcast, a futures mode is supported. The datastructures are quite
 //! similar to the normal ones, except they implement the Futures Sink/Stream traits for
 //! senders and receivers. This comes at a bit of a performance cost, which is why the
 //! futures types are separate
 //!
-//! #Usage:
+//! # Usage:
 //! From the receiving side, this behaves quite similarly to a channel receiver.
 //! The .recv function will block until data is available and then return the data.
 //!


### PR DESCRIPTION
One is in the lib and it's a bit of style normalization. 

Another is a API that's changed, the doc tests were fixed, but the `README.md` was not. related: https://github.com/rust-lang/cargo/issues/383

And the last one is just removing errant whitespace.

As a side note, the "Something wacky" section's sentence seems to be a product of a Markov chain. I have no idea what it's trying to say. It's wacky though. I haven't addressed that here as I can't understand it. 